### PR TITLE
fix: guard `std::integer_sequence` support for structured bindings (#20)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   x86_64-linux-gnu-gcc:
-    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/x86_64-linux-gnu-gcc.yml@v0.3.1
+    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/x86_64-linux-gnu-gcc.yml@v0.3.2

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   license:
-    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/license-checker.yml@v0.3.1
+    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/license-checker.yml@v0.3.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,14 +8,14 @@ on:
 
 jobs:
   tests:
-    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/x86_64-linux-gnu-gcc.yml@v0.3.1
+    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/x86_64-linux-gnu-gcc.yml@v0.3.2
     with:
       args: -DCMAKE_BUILD_TYPE=Debug
       target: ZTLTests
       post-build: ctest --test-dir build --schedule-random --timeout 86400
 
   include-what-you-must:
-    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/x86_64-linux-gnu-gcc.yml@v0.3.1
+    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/x86_64-linux-gnu-gcc.yml@v0.3.2
     with:
       args: -DCMAKE_BUILD_TYPE=Debug
       target: ZTLIncludeWhatYouMust

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.25.1
+- Bugfix guard `std::integer_sequence` support for structured bindings ([#20](https://github.com/ZIMO-Elektronik/ZTL/issues/20))
+
 ## 0.25.0
 - Add `make_logspace` to `<math.hpp>`
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ include(FetchContent)
 FetchContent_Declare(
   CMakeModules
   GIT_REPOSITORY "https://github.com/ZIMO-Elektronik/CMakeModules"
-  GIT_TAG v0.12.3
+  GIT_TAG v0.12.4
   SOURCE_DIR ${CMAKE_BINARY_DIR}/CMakeModules)
 FetchContent_MakeAvailable(CMakeModules)
 

--- a/include/ztl/utility.hpp
+++ b/include/ztl/utility.hpp
@@ -16,7 +16,9 @@
 #include "bits.hpp"
 #include "type_traits.hpp"
 
-// Make std::integer_sequence tuple-like accessible
+// https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p1789r2.pdf
+#if !defined(__glibcxx_integer_sequence) || __glibcxx_integer_sequence < 202511L
+
 namespace std {
 
 template<typename T, T... Is>
@@ -24,11 +26,20 @@ struct tuple_size<integer_sequence<T, Is...>>
   : integral_constant<size_t, sizeof...(Is)> {};
 
 template<size_t I, typename T, T... Is>
+requires(I < sizeof...(Is))
 struct tuple_element<I, integer_sequence<T, Is...>> {
-  using type = tuple_element_t<I, tuple<integral_constant<T, Is>...>>;
+  using type = T;
 };
 
+template<size_t I, typename T, T... Is>
+requires(I < sizeof...(Is))
+constexpr T get(integer_sequence<T, Is...>) noexcept {
+  return get<I>(tuple{Is...});
+}
+
 } // namespace std
+
+#endif
 
 namespace ztl {
 
@@ -82,19 +93,6 @@ template<typename T, T I, typename U, U J>
 constexpr auto operator/(std::integral_constant<T, I>,
                          std::integral_constant<U, J>) {
   return std::integral_constant<std::common_type_t<T, U>, I / J>{};
-}
-
-/// Extracts the Ith element from an integer sequence
-///
-/// \tparam I                               Element to access
-/// \tparam T                               Type of integer sequence
-/// \tparam Is...                           Integers
-/// \param  std::integer_sequence<T, Is...> Integer sequence
-/// \return Selected element of integer sequence
-template<size_t I, typename T, T... Is>
-constexpr auto get(std::integer_sequence<T, Is...>) {
-  static_assert(I < sizeof...(Is));
-  return std::tuple_element_t<I, std::integer_sequence<T, Is...>>{};
 }
 
 namespace detail {

--- a/tests/utility.cpp
+++ b/tests/utility.cpp
@@ -13,16 +13,6 @@ private:
 
 } // namespace
 
-TEST(utility, get) {
-  auto is{std::integer_sequence<int, 1, 2, 3>{}};
-  static_assert((
-    std::same_as<decltype(ztl::get<0uz>(is)), std::integral_constant<int, 1>>));
-  static_assert((
-    std::same_as<decltype(ztl::get<1uz>(is)), std::integral_constant<int, 2>>));
-  static_assert((
-    std::same_as<decltype(ztl::get<2uz>(is)), std::integral_constant<int, 3>>));
-}
-
 // Convert index sequence to bitmask
 TEST(utility, index_sequence2mask) {
   {


### PR DESCRIPTION
Closes #20 